### PR TITLE
Bumps open-aea and open-autonomy to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,12 +15,12 @@ asn1crypto = "==1.4.0"
 grpcio = "==1.53.0"
 hypothesis = "==6.21.6"
 eth-abi = "==4.0.0"
-open-aea = {version = "==1.48.0", extras = ["all"]}
-open-aea-ledger-ethereum = "==1.48.0"
-open-aea-ledger-cosmos = "==1.48.0"
-open-aea-cli-ipfs = "==1.48.0"
-open-aea-test-autonomy = "==0.14.6"
-open-autonomy = {version = "==0.14.6", extras = ["all"]}
+open-aea = {version = "==1.48.0.post1", extras = ["all"]}
+open-aea-ledger-ethereum = "==1.48.0.post1"
+open-aea-ledger-cosmos = "==1.48.0.post1"
+open-aea-cli-ipfs = "==1.48.0.post1"
+open-aea-test-autonomy = "==0.14.7"
+open-autonomy = {version = "==0.14.7", extras = ["all"]}
 pytz = "==2022.2.1"
 py-ecc = "==6.0.0"
 ### tests deps

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ In order to run a local demo of the Price Oracle service with a Hardhat node:
 2. Fetch the Price Oracle service.
 
 	```bash
-	autonomy fetch valory/oracle:0.1.0:bafybeicbazmticpvucdwcdhqo5fke6rdec4tvfid3zlvk4iv6fgcoaezfe --service
+	autonomy fetch valory/oracle:0.1.0:bafybeihtqeb4vnothhnvvwny4onni46egttqjv427h2jypwl333a66d6pi --service
 	```
 
 3. Build the Docker image of the service agents

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,11 +1,11 @@
 {
     "dev": {
-        "contract/valory/offchain_aggregator/0.1.0": "bafybeic3arg733rc2hcbuluitp2qtv2hrl3lw2vcyl736bhacetviokm6u",
-        "skill/valory/oracle_deployment_abci/0.1.0": "bafybeibqegny7rrj7fgbith5qfoafofvs23dg3cfyf4ti5chrwdcuw7oiy",
-        "skill/valory/price_estimation_abci/0.1.0": "bafybeihll5kizdfkwbk3yqqggwpupbvl6dfi3ru3ci5ae5zt34natzel7m",
-        "skill/valory/oracle_abci/0.1.0": "bafybeia5blnhtvllprcs55hmnkddwmpcfcigahu62xxa7nyzeadp2z2vvq",
-        "agent/valory/oracle/0.1.0": "bafybeidycgnic4cn57yit6dqbktykdp4svifbbxkvndrpg6ym2ddto7vem",
-        "service/valory/oracle/0.1.0": "bafybeicbazmticpvucdwcdhqo5fke6rdec4tvfid3zlvk4iv6fgcoaezfe"
+        "contract/valory/offchain_aggregator/0.1.0": "bafybeickenshmea7ugokmpnau32jg3iofpebhmyzqnn3wxny7zpwcqndmi",
+        "skill/valory/oracle_deployment_abci/0.1.0": "bafybeia3ojdomkdfiz25hawex3zz6iivwmcuugyjlmeqjkzehlrj3t3lda",
+        "skill/valory/price_estimation_abci/0.1.0": "bafybeid4xcgpwuhgus6xybprkk6qy6a2lgxoein4jka62pxj2s7qyj6dxq",
+        "skill/valory/oracle_abci/0.1.0": "bafybeigqema6ddnbpycxpkwxzrlchfzorcms6loxidizqviqvp374ao7uq",
+        "agent/valory/oracle/0.1.0": "bafybeiakfidjeuougexxlzltcj4ikxlzcjomr4insirhct7msqxkkqzvpq",
+        "service/valory/oracle/0.1.0": "bafybeihtqeb4vnothhnvvwny4onni46egttqjv427h2jypwl333a66d6pi"
     },
     "third_party": {
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
@@ -16,21 +16,21 @@
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeie6ynnoavvk2fpbn426nlp32sxrj7pz5esgebtlezy4tmx5gjretm",
-        "contract/valory/service_registry/0.1.0": "bafybeiby5x4wfdywlenmoudbykdxohpq2nifqxfep5niqgxrjyrekyahzy",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeiegrcfqdqrp23p4u727ic7uybtdvseibzzm3rvyshfdfpqrffut5m",
+        "contract/valory/service_registry/0.1.0": "bafybeichwywpb7nwxdx7ytqke55fij3fth36ozkceo7kth4szx4ie4pouy",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "connection/valory/ipfs/0.1.0": "bafybeiflaxrnepfn4hcnq5pieuc7ki7d422y3iqb54lv4tpgs7oywnuhhq",
-        "connection/valory/abci/0.1.0": "bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq",
+        "connection/valory/ipfs/0.1.0": "bafybeic7zx3tprybs7whs2odzsvqff2ohwaymo7calhki3nsdbokubhqte",
+        "connection/valory/abci/0.1.0": "bafybeichtqrs5wafa23zli4365ph74ve345c7qf4hyhwkywvln4ccn2jrm",
         "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
         "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe",
-        "skill/valory/registration_abci/0.1.0": "bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea",
-        "skill/valory/termination_abci/0.1.0": "bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay"
+        "skill/valory/abstract_abci/0.1.0": "bafybeiap7xqpci6pjlpd2yrmkguuohvsbycz725jpvz3xbgt6e2or5iucu",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4",
+        "skill/valory/registration_abci/0.1.0": "bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li",
+        "skill/valory/termination_abci/0.1.0": "bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze"
     }
 }

--- a/packages/valory/agents/oracle/aea-config.yaml
+++ b/packages/valory/agents/oracle/aea-config.yaml
@@ -12,15 +12,15 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeifbnhe4f2bll3a5o3hqji3dqx4soov7hr266rdz5vunxgzo5hggbq
+- valory/abci:0.1.0:bafybeichtqrs5wafa23zli4365ph74ve345c7qf4hyhwkywvln4ccn2jrm
 - valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
 - valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
-- valory/gnosis_safe_proxy_factory:0.1.0:bafybeie6ynnoavvk2fpbn426nlp32sxrj7pz5esgebtlezy4tmx5gjretm
-- valory/offchain_aggregator:0.1.0:bafybeic3arg733rc2hcbuluitp2qtv2hrl3lw2vcyl736bhacetviokm6u
-- valory/service_registry:0.1.0:bafybeiby5x4wfdywlenmoudbykdxohpq2nifqxfep5niqgxrjyrekyahzy
+- valory/gnosis_safe:0.1.0:bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4
+- valory/gnosis_safe_proxy_factory:0.1.0:bafybeiegrcfqdqrp23p4u727ic7uybtdvseibzzm3rvyshfdfpqrffut5m
+- valory/offchain_aggregator:0.1.0:bafybeickenshmea7ugokmpnau32jg3iofpebhmyzqnn3wxny7zpwcqndmi
+- valory/service_registry:0.1.0:bafybeichwywpb7nwxdx7ytqke55fij3fth36ozkceo7kth4szx4ie4pouy
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/abci:0.1.0:bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u
@@ -30,15 +30,15 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 - valory/tendermint:0.1.0:bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra
 skills:
-- valory/abstract_abci:0.1.0:bafybeihljirk3d4rgvmx2nmz3p2mp27iwh2o5euce5gccwjwrpawyjzuaq
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/oracle_abci:0.1.0:bafybeia5blnhtvllprcs55hmnkddwmpcfcigahu62xxa7nyzeadp2z2vvq
-- valory/oracle_deployment_abci:0.1.0:bafybeibqegny7rrj7fgbith5qfoafofvs23dg3cfyf4ti5chrwdcuw7oiy
-- valory/price_estimation_abci:0.1.0:bafybeihll5kizdfkwbk3yqqggwpupbvl6dfi3ru3ci5ae5zt34natzel7m
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_abci:0.1.0:bafybeiap7xqpci6pjlpd2yrmkguuohvsbycz725jpvz3xbgt6e2or5iucu
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/oracle_abci:0.1.0:bafybeigqema6ddnbpycxpkwxzrlchfzorcms6loxidizqviqvp374ao7uq
+- valory/oracle_deployment_abci:0.1.0:bafybeia3ojdomkdfiz25hawex3zz6iivwmcuugyjlmeqjkzehlrj3t3lda
+- valory/price_estimation_abci:0.1.0:bafybeid4xcgpwuhgus6xybprkk6qy6a2lgxoein4jka62pxj2s7qyj6dxq
+- valory/registration_abci:0.1.0:bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue
+- valory/reset_pause_abci:0.1.0:bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li
+- valory/termination_abci:0.1.0:bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -70,11 +70,11 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-cosmos:
-    version: ==1.48.0
+    version: ==1.48.0.post1
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.48.0.post1
   open-aea-test-autonomy:
-    version: ==0.14.6
+    version: ==0.14.7
 skill_exception_policy: stop_and_exit
 connection_exception_policy: just_log
 default_connection: null

--- a/packages/valory/contracts/offchain_aggregator/contract.yaml
+++ b/packages/valory/contracts/offchain_aggregator/contract.yaml
@@ -21,8 +21,8 @@ dependencies:
   eth-abi:
     version: ==4.0.0
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.48.0.post1
   open-aea-test-autonomy:
-    version: ==0.14.6
+    version: ==0.14.7
   eth-typing:
     version: ==3.4.0

--- a/packages/valory/services/oracle/service.yaml
+++ b/packages/valory/services/oracle/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeidfvq6yso3dpxgglq7fvviy42xjf3s7bn5thmi7ogv2j6pag3rene
 fingerprint_ignore_patterns: []
-agent: valory/oracle:0.1.0:bafybeidycgnic4cn57yit6dqbktykdp4svifbbxkvndrpg6ym2ddto7vem
+agent: valory/oracle:0.1.0:bafybeiakfidjeuougexxlzltcj4ikxlzcjomr4insirhct7msqxkkqzvpq
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/oracle_abci/skill.yaml
+++ b/packages/valory/skills/oracle_abci/skill.yaml
@@ -30,13 +30,13 @@ protocols:
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/oracle_deployment_abci:0.1.0:bafybeibqegny7rrj7fgbith5qfoafofvs23dg3cfyf4ti5chrwdcuw7oiy
-- valory/price_estimation_abci:0.1.0:bafybeihll5kizdfkwbk3yqqggwpupbvl6dfi3ru3ci5ae5zt34natzel7m
-- valory/registration_abci:0.1.0:bafybeif3ln6eg53ebrfe6uicjew4uqp2ynyrcxkw5wi4jm3ixqv3ykte4a
-- valory/reset_pause_abci:0.1.0:bafybeicm7onl72rfnn33pbvzwjpkl5gafeieyobfcnyresxz7kunjwmqea
-- valory/termination_abci:0.1.0:bafybeie6h7j4hyhgj2wte64n3xyudxq4pgqcqjmslxi5tff4mb6vce2tay
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/oracle_deployment_abci:0.1.0:bafybeia3ojdomkdfiz25hawex3zz6iivwmcuugyjlmeqjkzehlrj3t3lda
+- valory/price_estimation_abci:0.1.0:bafybeid4xcgpwuhgus6xybprkk6qy6a2lgxoein4jka62pxj2s7qyj6dxq
+- valory/registration_abci:0.1.0:bafybeibfzntdwfzvddh2hzmaun23724y7neq5koowxzjbxsevs3igntfue
+- valory/reset_pause_abci:0.1.0:bafybeienpu6guwbkdzscnovmhizuzlkpalycltzxnwovisbd2coyjim7li
+- valory/termination_abci:0.1.0:bafybeicklx5s3mjl4pgkcz36bw2vuuqj6w73qyh455vkoncyanxqlns6ze
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 behaviours:
   main:
     args: {}
@@ -214,5 +214,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-test-autonomy:
-    version: ==0.14.6
+    version: ==0.14.7
 is_abstract: false

--- a/packages/valory/skills/oracle_deployment_abci/skill.yaml
+++ b/packages/valory/skills/oracle_deployment_abci/skill.yaml
@@ -23,13 +23,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/offchain_aggregator:0.1.0:bafybeic3arg733rc2hcbuluitp2qtv2hrl3lw2vcyl736bhacetviokm6u
+- valory/offchain_aggregator:0.1.0:bafybeickenshmea7ugokmpnau32jg3iofpebhmyzqnn3wxny7zpwcqndmi
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
 behaviours:
   main:
     args: {}
@@ -163,5 +163,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.48.0
+    version: ==1.48.0.post1
 is_abstract: true

--- a/packages/valory/skills/price_estimation_abci/skill.yaml
+++ b/packages/valory/skills/price_estimation_abci/skill.yaml
@@ -33,16 +33,16 @@ fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeictjc7saviboxbsdcey3trvokrgo7uoh76mcrxecxhlvcrp47aqg4
-- valory/offchain_aggregator:0.1.0:bafybeic3arg733rc2hcbuluitp2qtv2hrl3lw2vcyl736bhacetviokm6u
+- valory/gnosis_safe:0.1.0:bafybeidrguivprxfv3doys4s47uttqnr6m47ah5wbcfbczgp3m6nivclr4
+- valory/offchain_aggregator:0.1.0:bafybeickenshmea7ugokmpnau32jg3iofpebhmyzqnn3wxny7zpwcqndmi
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeigjrepaqpb3m7zunmt4hryos4vto4yyj3u6iyofdb2fotwho3bqvm
-- valory/oracle_deployment_abci:0.1.0:bafybeibqegny7rrj7fgbith5qfoafofvs23dg3cfyf4ti5chrwdcuw7oiy
-- valory/transaction_settlement_abci:0.1.0:bafybeid57tozt5f3kgzmu22nbr3c3oy4p7bi2bu66rqsgnlylq6xgh2ixe
+- valory/abstract_round_abci:0.1.0:bafybeifrsatxr4syaccaxnirpvm2zetttlmrp3vr3fmqm7vc7lazy4i2bm
+- valory/oracle_deployment_abci:0.1.0:bafybeia3ojdomkdfiz25hawex3zz6iivwmcuugyjlmeqjkzehlrj3t3lda
+- valory/transaction_settlement_abci:0.1.0:bafybeihcfbjnty6j4aluaajgfdrc4ctg76ebb3gfub5pwqtooait7x76r4
 behaviours:
   main:
     args: {}
@@ -212,5 +212,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-test-autonomy:
-    version: ==0.14.6
+    version: ==0.14.7
 is_abstract: true

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,9 @@ deps =
     hypothesis==6.21.6
     joblib==1.1.0
     numpy>=1.21.6
-    open-aea-ledger-cosmos==1.48.0
-    open-aea-test-autonomy==0.14.6
-    open-autonomy[all]==0.14.6
+    open-aea-ledger-cosmos==1.48.0.post1
+    open-aea-test-autonomy==0.14.7
+    open-autonomy[all]==0.14.7
     pandas>=1.5.3
     pandas-stubs==1.2.0.62
     pytz==2022.2.1
@@ -271,7 +271,7 @@ skipsdist = True
 usedevelop = True
 deps = 
     protobuf<4.25.0,>=4.21.6
-    open-autonomy[all]==0.14.6
+    open-autonomy[all]==0.14.7
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum-flashbots to ==1.48.0.post1
- Bumps open-aea-ledger-ethereum-hwi to ==1.48.0.post1
- Bumps open-aea-ledger-cosmos to ==1.48.0.post1
- Bumps open-aea-ledger-solana to ==1.48.0.post1
- Bumps open-aea-cli-ipfs to ==1.48.0.post1
- Bumps open-autonomy to ==0.14.7
- Bumps open-aea-test-autonomy to ==0.14.7