### PR TITLE
Bumps frameworks to latest

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,12 +15,12 @@ asn1crypto = "==1.4.0"
 grpcio = "==1.53.0"
 hypothesis = "==6.21.6"
 eth-abi = "==4.0.0"
-open-aea = {version = "==1.50.0", extras = ["all"]}
-open-aea-ledger-ethereum = "==1.50.0"
-open-aea-ledger-cosmos = "==1.50.0"
-open-aea-cli-ipfs = "==1.50.0"
-open-aea-test-autonomy = "==0.14.10"
-open-autonomy = {version = "==0.14.10", extras = ["all"]}
+open-aea = {version = "==1.51.0", extras = ["all"]}
+open-aea-ledger-ethereum = "==1.51.0"
+open-aea-ledger-cosmos = "==1.51.0"
+open-aea-cli-ipfs = "==1.51.0"
+open-aea-test-autonomy = "==0.14.11"
+open-autonomy = {version = "==0.14.11", extras = ["all"]}
 pytz = "==2022.2.1"
 py-ecc = "==6.0.0"
 ### tests deps

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,14 +27,14 @@ In order to run a local demo of the Price Oracle service with a Hardhat node:
     mkdir your_workspace && cd your_workspace
     touch Pipfile && pipenv --python 3.10 && pipenv shell
 
-    pipenv install open-autonomy[all]==0.14.6
+    pipenv install open-autonomy[all]==0.14.11
     autonomy init --remote --ipfs --reset --author=your_name
     ```
 
 2. Fetch the Price Oracle service.
 
 	```bash
-	autonomy fetch valory/oracle:0.1.0:bafybeib5q5rjt4oi22txpkqapw5ofwkhpiqcibczhe7cyfxij2wckcesh4 --service
+	autonomy fetch valory/oracle:0.1.0:bafybeifb4sb4qzp6l4es52gvckiutcmyif7goxsojgamgh3ocx674sjizq --service
 	```
 
 3. Build the Docker image of the service agents

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,11 +1,11 @@
 {
     "dev": {
-        "contract/valory/offchain_aggregator/0.1.0": "bafybeiggpiyn62cuifsp4lje2vlstxjh3hnfdqy6as7azdnqgysonlppsy",
-        "skill/valory/oracle_deployment_abci/0.1.0": "bafybeiewkximkiqerl6owgapfpjsudfmbm4rphcv7bjblupqo67aqo5osa",
-        "skill/valory/price_estimation_abci/0.1.0": "bafybeidy747coldkvfgmqlbartedyxrbmrsu2txk5aifugy7m54hprezgu",
-        "skill/valory/oracle_abci/0.1.0": "bafybeifxvtdlonfugyiw4zsmi3kffau6vkx2rsrzkdy3kajkrz3n755s2q",
-        "agent/valory/oracle/0.1.0": "bafybeiafmboaybe3dsoo2e4cilf3m334c5dhpjws54pbwqnm5ksnrkctrq",
-        "service/valory/oracle/0.1.0": "bafybeib5q5rjt4oi22txpkqapw5ofwkhpiqcibczhe7cyfxij2wckcesh4"
+        "contract/valory/offchain_aggregator/0.1.0": "bafybeihylhpw3zo7ekeqc3rmzli7zmndjvba5bby6kfdddpq4wuay4o6xy",
+        "skill/valory/oracle_deployment_abci/0.1.0": "bafybeigd2jfr4ny4sfnfifdkxwkpopam5gfkxv3fd47bljb5bpulgmimie",
+        "skill/valory/price_estimation_abci/0.1.0": "bafybeiehrctjvr7qiflhe6cx6hc3fcflkcnsnni6accujhoi2i5st7dtxy",
+        "skill/valory/oracle_abci/0.1.0": "bafybeig2xhv64a3dvdgjft2ohqdqwqojrplkacodglkjmiu6zenhmrnqly",
+        "agent/valory/oracle/0.1.0": "bafybeigrsn3hrmao6df4p2ia6aw2r7bzaebm5lq7ggi3jhbtqqupchnmre",
+        "service/valory/oracle/0.1.0": "bafybeifb4sb4qzp6l4es52gvckiutcmyif7goxsojgamgh3ocx674sjizq"
     },
     "third_party": {
         "protocol/valory/ipfs/0.1.0": "bafybeiftxi2qhreewgsc5wevogi7yc5g6hbcbo4uiuaibauhv3nhfcdtvm",
@@ -16,21 +16,21 @@
         "protocol/open_aea/signing/1.0.0": "bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi",
         "protocol/valory/tendermint/0.1.0": "bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra",
         "protocol/valory/acn/1.1.0": "bafybeidluaoeakae3exseupaea4i3yvvk5vivyt227xshjlffywwxzcxqe",
-        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74",
-        "contract/valory/service_registry/0.1.0": "bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm",
-        "contract/valory/gnosis_safe/0.1.0": "bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa",
+        "contract/valory/gnosis_safe_proxy_factory/0.1.0": "bafybeic5dql7cmwrbabgp47s5tfvdmurm2rxl3jfpda76urdnehiaidq4e",
+        "contract/valory/service_registry/0.1.0": "bafybeicl7756aaactmuazwnouua27vo6mkh4fzoikg2sv3mv2mlbqpifpq",
+        "contract/valory/gnosis_safe/0.1.0": "bafybeie53qvfrzkhuaxtazcqjiseo2ax2o74nytzfvb6wbgijv3p5svto4",
         "contract/valory/multisend/0.1.0": "bafybeig5byt5urg2d2bsecufxe5ql7f4mezg3mekfleeh32nmuusx66p4y",
-        "connection/valory/ipfs/0.1.0": "bafybeihndk6hohj3yncgrye5pw7b7w2kztj3avby5u5mfk2fpjh7hqphii",
-        "connection/valory/abci/0.1.0": "bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze",
-        "connection/valory/http_client/0.23.0": "bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm",
-        "connection/valory/ledger/0.19.0": "bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya",
+        "connection/valory/ipfs/0.1.0": "bafybeifqca6e232lbvwrjhd7ioh43bo3evxfkpumdvcr6re2sdwjuntgna",
+        "connection/valory/abci/0.1.0": "bafybeib7hxfzqm6fmtv73rb5gv22mv7tzweerge4jyfaxl2v5bf3ohxyf4",
+        "connection/valory/http_client/0.23.0": "bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u",
+        "connection/valory/ledger/0.19.0": "bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e",
         "connection/valory/http_server/0.22.0": "bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m",
-        "skill/valory/abstract_abci/0.1.0": "bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum",
-        "skill/valory/abstract_round_abci/0.1.0": "bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i",
-        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq",
-        "skill/valory/registration_abci/0.1.0": "bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm",
-        "skill/valory/reset_pause_abci/0.1.0": "bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam",
-        "skill/valory/termination_abci/0.1.0": "bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44"
+        "skill/valory/abstract_abci/0.1.0": "bafybeicpmdv62m2mgzkvircr6lmp3vohwombe4hixgooeeqwf7vvb5lwqa",
+        "skill/valory/abstract_round_abci/0.1.0": "bafybeieizi5fg45l72lgohfi34bzgn7ejqd6s5jxbcklwxfjtenpndztfi",
+        "skill/valory/transaction_settlement_abci/0.1.0": "bafybeicqpmlkz22dodkul5672zqsagu5upzmt2djyo3rrc7xs2ttxanjgy",
+        "skill/valory/registration_abci/0.1.0": "bafybeiffjshiqdszr3rvcuyynyitwqagfoewil2324moby6obxubzc2wla",
+        "skill/valory/reset_pause_abci/0.1.0": "bafybeiali66vbm7haj5zonihdr5u3audcwcu4ojlfnmw5gbu42fm5pzowi",
+        "skill/valory/termination_abci/0.1.0": "bafybeiecnsmeng5sjzalbrbuc7ryabtpsiu7f474uyywkmaszzicwnpmqi"
     }
 }

--- a/packages/valory/agents/oracle/aea-config.yaml
+++ b/packages/valory/agents/oracle/aea-config.yaml
@@ -12,15 +12,15 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
-- valory/abci:0.1.0:bafybeiclexb6cnsog5yjz2qtvqyfnf7x5m7tpp56hblhk3pbocbvgjzhze
-- valory/http_client:0.23.0:bafybeih5vzo22p2umhqo52nzluaanxx7kejvvpcpdsrdymckkyvmsim6gm
-- valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
+- valory/abci:0.1.0:bafybeib7hxfzqm6fmtv73rb5gv22mv7tzweerge4jyfaxl2v5bf3ohxyf4
+- valory/http_client:0.23.0:bafybeihi772xgzpqeipp3fhmvpct4y6e6tpjp4sogwqrnf3wqspgeilg4u
+- valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 - valory/p2p_libp2p_client:0.1.0:bafybeid3xg5k2ol5adflqloy75ibgljmol6xsvzvezebsg7oudxeeolz7e
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa
-- valory/gnosis_safe_proxy_factory:0.1.0:bafybeib6podeifufgmawvicm3xyz3uaplbcrsptjzz4unpseh7qtcpar74
-- valory/offchain_aggregator:0.1.0:bafybeiggpiyn62cuifsp4lje2vlstxjh3hnfdqy6as7azdnqgysonlppsy
-- valory/service_registry:0.1.0:bafybeicbxmbzt757lbmyh6762lrkcrp3oeum6dk3z7pvosixasifsk6xlm
+- valory/gnosis_safe:0.1.0:bafybeie53qvfrzkhuaxtazcqjiseo2ax2o74nytzfvb6wbgijv3p5svto4
+- valory/gnosis_safe_proxy_factory:0.1.0:bafybeic5dql7cmwrbabgp47s5tfvdmurm2rxl3jfpda76urdnehiaidq4e
+- valory/offchain_aggregator:0.1.0:bafybeihylhpw3zo7ekeqc3rmzli7zmndjvba5bby6kfdddpq4wuay4o6xy
+- valory/service_registry:0.1.0:bafybeicl7756aaactmuazwnouua27vo6mkh4fzoikg2sv3mv2mlbqpifpq
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/abci:0.1.0:bafybeiaqmp7kocbfdboksayeqhkbrynvlfzsx4uy4x6nohywnmaig4an7u
@@ -30,15 +30,15 @@ protocols:
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 - valory/tendermint:0.1.0:bafybeig4mi3vmlv5zpbjbfuzcgida6j5f2nhrpedxicmrrfjweqc5r7cra
 skills:
-- valory/abstract_abci:0.1.0:bafybeihat4giyc4bz6zopvahcj4iw53356pbtwfn7p4d5yflwly2qhahum
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/oracle_abci:0.1.0:bafybeifxvtdlonfugyiw4zsmi3kffau6vkx2rsrzkdy3kajkrz3n755s2q
-- valory/oracle_deployment_abci:0.1.0:bafybeiewkximkiqerl6owgapfpjsudfmbm4rphcv7bjblupqo67aqo5osa
-- valory/price_estimation_abci:0.1.0:bafybeidy747coldkvfgmqlbartedyxrbmrsu2txk5aifugy7m54hprezgu
-- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
-- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
-- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
-- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
+- valory/abstract_abci:0.1.0:bafybeicpmdv62m2mgzkvircr6lmp3vohwombe4hixgooeeqwf7vvb5lwqa
+- valory/abstract_round_abci:0.1.0:bafybeieizi5fg45l72lgohfi34bzgn7ejqd6s5jxbcklwxfjtenpndztfi
+- valory/oracle_abci:0.1.0:bafybeig2xhv64a3dvdgjft2ohqdqwqojrplkacodglkjmiu6zenhmrnqly
+- valory/oracle_deployment_abci:0.1.0:bafybeigd2jfr4ny4sfnfifdkxwkpopam5gfkxv3fd47bljb5bpulgmimie
+- valory/price_estimation_abci:0.1.0:bafybeiehrctjvr7qiflhe6cx6hc3fcflkcnsnni6accujhoi2i5st7dtxy
+- valory/registration_abci:0.1.0:bafybeiffjshiqdszr3rvcuyynyitwqagfoewil2324moby6obxubzc2wla
+- valory/reset_pause_abci:0.1.0:bafybeiali66vbm7haj5zonihdr5u3audcwcu4ojlfnmw5gbu42fm5pzowi
+- valory/termination_abci:0.1.0:bafybeiecnsmeng5sjzalbrbuc7ryabtpsiu7f474uyywkmaszzicwnpmqi
+- valory/transaction_settlement_abci:0.1.0:bafybeicqpmlkz22dodkul5672zqsagu5upzmt2djyo3rrc7xs2ttxanjgy
 default_ledger: ethereum
 required_ledgers:
 - ethereum
@@ -70,11 +70,11 @@ logging_config:
       propagate: true
 dependencies:
   open-aea-ledger-cosmos:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-ledger-ethereum:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11
 skill_exception_policy: stop_and_exit
 connection_exception_policy: just_log
 default_connection: null

--- a/packages/valory/contracts/offchain_aggregator/contract.yaml
+++ b/packages/valory/contracts/offchain_aggregator/contract.yaml
@@ -21,8 +21,8 @@ dependencies:
   eth-abi:
     version: ==4.0.0
   open-aea-ledger-ethereum:
-    version: ==1.50.0
+    version: ==1.51.0
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11
   eth-typing:
     version: ==3.4.0

--- a/packages/valory/services/oracle/service.yaml
+++ b/packages/valory/services/oracle/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeidfvq6yso3dpxgglq7fvviy42xjf3s7bn5thmi7ogv2j6pag3rene
 fingerprint_ignore_patterns: []
-agent: valory/oracle:0.1.0:bafybeiafmboaybe3dsoo2e4cilf3m334c5dhpjws54pbwqnm5ksnrkctrq
+agent: valory/oracle:0.1.0:bafybeigrsn3hrmao6df4p2ia6aw2r7bzaebm5lq7ggi3jhbtqqupchnmre
 number_of_agents: 4
 deployment:
   agent:

--- a/packages/valory/skills/oracle_abci/skill.yaml
+++ b/packages/valory/skills/oracle_abci/skill.yaml
@@ -23,20 +23,20 @@ fingerprint:
   tests/test_models.py: bafybeibqcmwyunbxdoyhorypukrt3bxgvvm3yff7prdkbaenysxoix4e3u
 fingerprint_ignore_patterns: []
 connections:
-- valory/ledger:0.19.0:bafybeic3ft7l7ca3qgnderm4xupsfmyoihgi27ukotnz7b5hdczla2enya
+- valory/ledger:0.19.0:bafybeig7woeog4srdby75hpjkmx4rhpkzncbf4h2pm5r6varsp26pf2uhu
 contracts: []
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/oracle_deployment_abci:0.1.0:bafybeiewkximkiqerl6owgapfpjsudfmbm4rphcv7bjblupqo67aqo5osa
-- valory/price_estimation_abci:0.1.0:bafybeidy747coldkvfgmqlbartedyxrbmrsu2txk5aifugy7m54hprezgu
-- valory/registration_abci:0.1.0:bafybeiek7zcsxbucjwzgqfftafhfrocvc7q4yxllh2q44jeemsjxg3rcfm
-- valory/reset_pause_abci:0.1.0:bafybeidw4mbx3os3hmv7ley7b3g3gja7ydpitr7mxbjpwzxin2mzyt5yam
-- valory/termination_abci:0.1.0:bafybeihq6qtbwt6i53ayqym63vhjexkcppy26gguzhhjqywfmiuqghvv44
-- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
+- valory/abstract_round_abci:0.1.0:bafybeieizi5fg45l72lgohfi34bzgn7ejqd6s5jxbcklwxfjtenpndztfi
+- valory/oracle_deployment_abci:0.1.0:bafybeigd2jfr4ny4sfnfifdkxwkpopam5gfkxv3fd47bljb5bpulgmimie
+- valory/price_estimation_abci:0.1.0:bafybeiehrctjvr7qiflhe6cx6hc3fcflkcnsnni6accujhoi2i5st7dtxy
+- valory/registration_abci:0.1.0:bafybeiffjshiqdszr3rvcuyynyitwqagfoewil2324moby6obxubzc2wla
+- valory/reset_pause_abci:0.1.0:bafybeiali66vbm7haj5zonihdr5u3audcwcu4ojlfnmw5gbu42fm5pzowi
+- valory/termination_abci:0.1.0:bafybeiecnsmeng5sjzalbrbuc7ryabtpsiu7f474uyywkmaszzicwnpmqi
+- valory/transaction_settlement_abci:0.1.0:bafybeicqpmlkz22dodkul5672zqsagu5upzmt2djyo3rrc7xs2ttxanjgy
 behaviours:
   main:
     args: {}
@@ -214,5 +214,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11
 is_abstract: false

--- a/packages/valory/skills/oracle_deployment_abci/skill.yaml
+++ b/packages/valory/skills/oracle_deployment_abci/skill.yaml
@@ -23,13 +23,13 @@ fingerprint:
 fingerprint_ignore_patterns: []
 connections: []
 contracts:
-- valory/offchain_aggregator:0.1.0:bafybeiggpiyn62cuifsp4lje2vlstxjh3hnfdqy6as7azdnqgysonlppsy
+- valory/offchain_aggregator:0.1.0:bafybeihylhpw3zo7ekeqc3rmzli7zmndjvba5bby6kfdddpq4wuay4o6xy
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/ledger_api:1.0.0:bafybeihdk6psr4guxmbcrc26jr2cbgzpd5aljkqvpwo64bvaz7tdti2oni
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
+- valory/abstract_round_abci:0.1.0:bafybeieizi5fg45l72lgohfi34bzgn7ejqd6s5jxbcklwxfjtenpndztfi
 behaviours:
   main:
     args: {}
@@ -163,5 +163,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==1.50.0
+    version: ==1.51.0
 is_abstract: true

--- a/packages/valory/skills/price_estimation_abci/skill.yaml
+++ b/packages/valory/skills/price_estimation_abci/skill.yaml
@@ -33,16 +33,16 @@ fingerprint_ignore_patterns: []
 connections:
 - valory/http_server:0.22.0:bafybeihpgu56ovmq4npazdbh6y6ru5i7zuv6wvdglpxavsckyih56smu7m
 contracts:
-- valory/gnosis_safe:0.1.0:bafybeibq77mgzhyb23blf2eqmia3kc6io5karedfzhntvpcebeqdzrgyqa
-- valory/offchain_aggregator:0.1.0:bafybeiggpiyn62cuifsp4lje2vlstxjh3hnfdqy6as7azdnqgysonlppsy
+- valory/gnosis_safe:0.1.0:bafybeie53qvfrzkhuaxtazcqjiseo2ax2o74nytzfvb6wbgijv3p5svto4
+- valory/offchain_aggregator:0.1.0:bafybeihylhpw3zo7ekeqc3rmzli7zmndjvba5bby6kfdddpq4wuay4o6xy
 protocols:
 - open_aea/signing:1.0.0:bafybeihv62fim3wl2bayavfcg3u5e5cxu3b7brtu4cn5xoxd6lqwachasi
 - valory/contract_api:1.0.0:bafybeidgu7o5llh26xp3u3ebq3yluull5lupiyeu6iooi2xyymdrgnzq5i
 - valory/http:1.0.0:bafybeifugzl63kfdmwrxwphrnrhj7bn6iruxieme3a4ntzejf6kmtuwmae
 skills:
-- valory/abstract_round_abci:0.1.0:bafybeih3enhagoql7kzpeyzzu2scpkif6y3ubakpralfnwxcvxexdyvy5i
-- valory/oracle_deployment_abci:0.1.0:bafybeiewkximkiqerl6owgapfpjsudfmbm4rphcv7bjblupqo67aqo5osa
-- valory/transaction_settlement_abci:0.1.0:bafybeigtzlk4uakmd54rxnznorcrstsr52kta474lgrnvx5ovr546vj7sq
+- valory/abstract_round_abci:0.1.0:bafybeieizi5fg45l72lgohfi34bzgn7ejqd6s5jxbcklwxfjtenpndztfi
+- valory/oracle_deployment_abci:0.1.0:bafybeigd2jfr4ny4sfnfifdkxwkpopam5gfkxv3fd47bljb5bpulgmimie
+- valory/transaction_settlement_abci:0.1.0:bafybeicqpmlkz22dodkul5672zqsagu5upzmt2djyo3rrc7xs2ttxanjgy
 behaviours:
   main:
     args: {}
@@ -212,5 +212,5 @@ models:
     class_name: TendermintDialogues
 dependencies:
   open-aea-test-autonomy:
-    version: ==0.14.10
+    version: ==0.14.11
 is_abstract: true

--- a/setup.py
+++ b/setup.py
@@ -25,3 +25,4 @@ if __name__ == "__main__":
     setup(packages=[])
 
 
+

--- a/tox.ini
+++ b/tox.ini
@@ -24,9 +24,9 @@ deps =
     hypothesis==6.21.6
     joblib==1.1.0
     numpy>=1.21.6
-    open-aea-ledger-cosmos==1.50.0
-    open-aea-test-autonomy==0.14.10
-    open-autonomy[all]==0.14.10
+    open-aea-ledger-cosmos==1.51.0
+    open-aea-test-autonomy==0.14.11
+    open-autonomy[all]==0.14.11
     pandas>=1.5.3
     pandas-stubs==1.2.0.62
     pytz==2022.2.1
@@ -271,7 +271,7 @@ skipsdist = True
 usedevelop = True
 deps = 
     protobuf<4.25.0,>=4.21.6
-    open-autonomy[all]==0.14.10
+    open-autonomy[all]==0.14.11
 commands =
     autonomy init --reset --author ci --remote --ipfs --ipfs-node "/dns/registry.autonolas.tech/tcp/443/https"
     autonomy packages sync
@@ -638,7 +638,7 @@ fetchai-ledger-api: >=0.0.1
 chardet: >=3.0.4
 certifi: >=2019.11.28
 ;TODO: the following are conflicting packages that need to be sorted
-; sub-dep of open-aea-ledger-ethereum-hwi
+; sub-dep of open-aea-ledger-ethereum-hwi==1.51.0
 hidapi: >=0.13.2
 ; shows in pip freeze but not referenced on code
 paramiko: >=3.1.0


### PR DESCRIPTION
chore: bump
- Bumps open-aea to ==1.51.0
- Bumps open-aea-ledger-ethereum to ==1.51.0
- Bumps open-aea-ledger-ethereum-flashbots to ==1.51.0
- Bumps open-aea-ledger-ethereum-hwi to ==1.51.0
- Bumps open-aea-ledger-cosmos to ==1.51.0
- Bumps open-aea-ledger-solana to ==1.51.0
- Bumps open-aea-cli-ipfs to ==1.51.0
- Bumps open-autonomy to ==0.14.11
- Bumps open-aea-test-autonomy to ==0.14.11